### PR TITLE
Add isValidUTF8 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ otherwise the return value will be `false`.
 
 Test if the string _s_ is [the empty string].
 
+### `IsValidUTF8(s string) bool`
+
+Test if the string _s_ is a valid [UTF-8] string.
+
 ### `MapAll(elems []string, mapping func(string) string) []string`
 
 Create a new slice populated with the results of calling the _mapping_ on every
@@ -53,6 +57,7 @@ The license for this project is the same as the license for Golang
 [similar projects]: https://github.com/search?l=Go&q=stringsx&type=Repositories
 [`strings`]: https://golang.org/pkg/strings
 [the empty string]: https://en.wikipedia.org/wiki/Empty_string
+[UTF-8]: https://en.wikipedia.org/wiki/UTF-8
 
 [ci-url]: https://github.com/ericcornelissen/stringsx/actions?query=workflow%3AGo
 [ci-image]: https://github.com/ericcornelissen/stringsx/workflows/Go/badge.svg

--- a/custom.go
+++ b/custom.go
@@ -5,9 +5,12 @@ additional utility functions. Namely:
 	• All(elemens []string condition func(string) bool) bool
 	• Any(elems []string, condition func(string) bool) bool
 	• IsEmpty(s string) bool
+	• IsValidUTF8(s string) bool
 	• MapAll(elems []string, mapping func(string) string) (mapped []string)
 */
 package stringsx
+
+import "unicode/utf8"
 
 // All tests for every element of its first argument if the condition holds. If
 // the condition holds for every string the return value will be true, otherwise
@@ -38,6 +41,11 @@ func Any(elems []string, condition func(string) bool) bool {
 // IsEmpty tests whether the string s is the empty string.
 func IsEmpty(s string) bool {
 	return s == ""
+}
+
+// IsValidUTF8 tests whether the string s is a valid UTF-8 string.
+func IsValidUTF8(s string) bool {
+	return utf8.ValidString(s)
 }
 
 // MapAll maps every element of its first argument according to the provided

--- a/custom_test.go
+++ b/custom_test.go
@@ -26,6 +26,13 @@ func ExampleIsEmpty() {
 	// false
 }
 
+func ExampleIsValidUTF8() {
+	fmt.Println(IsValidUTF8("foobar"))
+	fmt.Println(IsValidUTF8("\xbf"))
+	// Output: true
+	// false
+}
+
 func ExampleMapAll() {
 	elems := []string{" foo  ", "  bar "}
 	mapped := MapAll(elems, TrimSpace)
@@ -134,6 +141,24 @@ func TestIsEmpty(t *testing.T) {
 
 	if isEmpty := IsEmpty("Hello world!"); isEmpty == true {
 		t.Error("Unexpected result for non-empty string")
+	}
+}
+
+func TestIsValidUTF8(t *testing.T) {
+	if valid := IsValidUTF8(""); valid == false {
+		t.Error("Unexpected result for empty string")
+	}
+
+	if valid := IsValidUTF8("Hello world!"); valid == false {
+		t.Error("Unexpected result for non-empty string")
+	}
+
+	if valid := IsValidUTF8("\xbf"); valid == true {
+		t.Error("Unexpected result for string of non-UTF8 characters")
+	}
+
+	if valid := IsValidUTF8("foo\xbf"); valid == true {
+		t.Error("Unexpected result for string with non-UTF8 characters")
 	}
 }
 


### PR DESCRIPTION
Add a new function to this `stringsx` package to test if a given string is a valid [UTF-8] string, i.e. if the string contains only characters that are in the [UTF-8] character set. The function is tested (including a testable example) and documented in the README.

The implementation of the function uses [the `ValidString` function of the standard `utf8` package](https://golang.org/pkg/unicode/utf8/#ValidString).

[UTF-8]: https://en.wikipedia.org/wiki/UTF-8